### PR TITLE
Feat: 엔티티 생성/수정 날짜 자동생성용 추상 클래스 추가, 채팅 조회 핸들러매핑 추가

### DIFF
--- a/src/main/java/king/ide/IdeApplication.java
+++ b/src/main/java/king/ide/IdeApplication.java
@@ -3,7 +3,9 @@ package king.ide;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class IdeApplication {
 

--- a/src/main/java/king/ide/controller/ChatController.java
+++ b/src/main/java/king/ide/controller/ChatController.java
@@ -7,7 +7,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -27,5 +29,23 @@ public class ChatController {
         chatService.save(message);
 
         messageSendingOperations.convertAndSend("/sub/chat/room/" + message.getRoomId(), message);
+    }
+
+    @GetMapping("/chat/roomId/{roomId}")
+    @ResponseBody
+    public List<ChatMessage> findMessageByRoomId(@PathVariable String roomId){
+        return chatService.findByRoomId(roomId);
+    }
+
+    @GetMapping("/chat/id/{id}")
+    @ResponseBody
+    public ChatMessage findMessageById(@PathVariable Long id) {
+        return chatService.findById(id);
+    }
+
+    @GetMapping("/chat/sender/{sender}")
+    @ResponseBody
+    public List<ChatMessage> findMessageBySender(@PathVariable String sender) {
+        return chatService.findBySender(sender);
     }
 }

--- a/src/main/java/king/ide/domain/ChatMessage.java
+++ b/src/main/java/king/ide/domain/ChatMessage.java
@@ -2,12 +2,12 @@ package king.ide.domain;
 
 import jakarta.persistence.*;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 @Entity
 @Data
-public class ChatMessage {
+public class ChatMessage extends DateEntity{
 
     // 메세지 타입 : 입장, 채팅, 퇴장
     public enum MessageType {

--- a/src/main/java/king/ide/domain/DateEntity.java
+++ b/src/main/java/king/ide/domain/DateEntity.java
@@ -1,0 +1,26 @@
+package king.ide.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class DateEntity {
+
+    @CreatedDate
+    @DateTimeFormat(pattern = "yyyy-mm-dd/HH:mm:ss")
+    private LocalDateTime createdAt;
+
+//    @LastModifiedDate
+//    @DateTimeFormat(pattern = "yyyy-mm-dd/HH:mm:ss")
+//    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/king/ide/repository/ChatRepository.java
+++ b/src/main/java/king/ide/repository/ChatRepository.java
@@ -4,11 +4,13 @@ import jakarta.persistence.EntityManager;
 import king.ide.domain.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
+@Transactional
 public class ChatRepository {
 
     private final EntityManager em;
@@ -24,4 +26,15 @@ public class ChatRepository {
                 .getResultList();
     }
 
+    public ChatMessage findById(Long id) {
+        return em.createQuery("select cm from ChatMessage cm where cm.id = :id", ChatMessage.class)
+                .setParameter("id", id)
+                .getSingleResult();
+    }
+
+    public List<ChatMessage> findBySender(String sender) {
+        return em.createQuery("select cm from ChatMessage cm where cm.sender = :sender", ChatMessage.class)
+                .setParameter("sender", sender)
+                .getResultList();
+    }
 }

--- a/src/main/java/king/ide/service/ChatService.java
+++ b/src/main/java/king/ide/service/ChatService.java
@@ -24,4 +24,12 @@ public class ChatService {
         return chatRepository.findByRoomId(roomId);
     }
 
+    public ChatMessage findById(Long id) {
+        return chatRepository.findById(id);
+    }
+
+    public List<ChatMessage> findBySender(String sender) {
+        return chatRepository.findBySender(sender);
+    }
+
 }


### PR DESCRIPTION
DateEntity를 상속 받은 엔티티는 db 저장 시 생성 날짜가 자동으로 등록되며, 수정 시 수정 날짜도 자동 반영됩니다.

[컨트롤러 매핑 추가사항]
1. 채팅방 아이디로 채팅 내역 조회
2. 유저 닉네임으로 채팅 내역 조회
3. 채팅 아이디로 채팅 단일 조회
